### PR TITLE
INTERNAL PR js-iden3-auth: VidosResolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/uuid": "^9.0.7",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
+        "did-resolver": "4.1.0",
         "eslint": "^8.13.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "tsc-alias": "^1.8.8",
     "tsconfig-paths": "^3.14.2",
     "typechain": "^8.1.1",
-    "typescript": "^4.3.5"
+    "typescript": "^4.3.5",
+    "did-resolver": "4.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * as auth from '@lib/auth/auth';
 export * as resolver from '@lib/state/resolver';
+export { default as VidosResolver } from '@lib/state/vidosResolver';
 export * as protocol from '@lib/types-sdk';
 export { core } from '@0xpolygonid/js-sdk';

--- a/src/state/vidosResolver.ts
+++ b/src/state/vidosResolver.ts
@@ -42,6 +42,9 @@ type DidResolutionResult = {
 export default class VidosResolver implements IStateResolver {
   constructor(private readonly resolverUrl: string, private readonly apiKey: string) {}
 
+  // Note: implementation closely resembles EthStateResolver because Vidos resolver internally uses the same contract. 
+  // The only difference is the usage of regular HTTP requests instead of web3 calls.
+
   async rootResolve(state: bigint): Promise<ResolvedState> {
     const stateHex = state.toString(16);
 

--- a/src/state/vidosResolver.ts
+++ b/src/state/vidosResolver.ts
@@ -42,7 +42,7 @@ type DidResolutionResult = {
 export default class VidosResolver implements IStateResolver {
   constructor(private readonly resolverUrl: string, private readonly apiKey: string) {}
 
-  // Note: implementation closely resembles EthStateResolver because Vidos resolver internally uses the same contract. 
+  // Note: implementation closely resembles EthStateResolver because Vidos resolver internally uses the same contract.
   // The only difference is the usage of regular HTTP requests instead of web3 calls.
 
   async rootResolve(state: bigint): Promise<ResolvedState> {

--- a/src/state/vidosResolver.ts
+++ b/src/state/vidosResolver.ts
@@ -53,6 +53,9 @@ export default class VidosResolver implements IStateResolver {
       }
     });
     const result = (await response.json()) as PolygonDidResolutionResult;
+    if (result.didResolutionMetadata.error) {
+      throw new Error(`error resolving DID: ${result.didResolutionMetadata.error}`);
+    }
 
     const globalInfo = result.didDocument.verificationMethod[0].global;
     if (globalInfo == null) throw new Error('gist info not found');
@@ -94,7 +97,11 @@ export default class VidosResolver implements IStateResolver {
         Authorization: `Bearer ${this.apiKey}`
       }
     });
-    const result = await response.json();
+    const result = (await response.json()) as PolygonDidResolutionResult;
+    if (result.didResolutionMetadata.error) {
+      throw new Error(`error resolving DID: ${result.didResolutionMetadata.error}`);
+    }
+
     const isGenesis = isGenesisStateId(id, state);
 
     const stateInfo = result.didDocument.verificationMethod[0].info;

--- a/src/state/vidosResolver.ts
+++ b/src/state/vidosResolver.ts
@@ -1,0 +1,137 @@
+import { Id } from '@iden3/js-iden3-core';
+import { type IStateResolver, type ResolvedState, isGenesisStateId } from './resolver';
+
+type DidResolutionResult = {
+  didResolutionMetadata: unknown;
+  didDocumentMetadata: unknown;
+  didDocument: {
+    id: string;
+    alsoKnownAs: string[];
+    controller: string;
+    verificationMethod: {
+      id: string;
+      type: string;
+      controller: string;
+      stateContractAddress: string;
+      published: boolean;
+      info: {
+        id: string;
+        state: string;
+        replacedByState: string;
+        createdAtTimestamp: string;
+        replacedAtTimestamp: string;
+        createdAtBlock: string;
+        replacedAtBlock: string;
+      };
+      global: {
+        root: string;
+        replacedByRoot: string;
+        createdAtTimestamp: string;
+        replacedAtTimestamp: string;
+        createdAtBlock: string;
+        replacedAtBlock: string;
+      };
+    }[];
+  };
+};
+
+/**
+ * Implementation of {@link IStateResolver} that uses Vidos resolver service to resolve states.
+ * It can serve as drop-in replacement for EthStateResolver.
+ */
+export default class VidosResolver implements IStateResolver {
+  constructor(
+    private readonly resolverUrl: string,
+    private readonly apiKey: string,
+  ) {}
+
+  async rootResolve(state: bigint): Promise<ResolvedState> {
+    const stateHex = state.toString(16);
+
+    const zeroAddress = '11111111111111111111'; // 1 is 0 in base58
+    const did = `did:polygonid:polygon:amoy:${zeroAddress}?gist=${stateHex}`;
+
+    const response = await fetch(
+      `${this.resolverUrl}/${encodeURIComponent(did)}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+      },
+    );
+    const result = (await response.json()) as DidResolutionResult;
+
+    const globalInfo = result.didDocument.verificationMethod[0].global;
+    if (globalInfo == null) throw new Error('gist info not found');
+
+    if (globalInfo.root !== stateHex) {
+      throw new Error('gist info contains invalid state');
+    }
+
+    if (globalInfo.replacedByRoot !== '0') {
+      if (globalInfo.replacedAtTimestamp === '0') {
+        throw new Error('state was replaced, but replaced time unknown');
+      }
+      return {
+        latest: false,
+        state: state,
+        transitionTimestamp: globalInfo.replacedAtTimestamp,
+        genesis: false,
+      };
+    }
+
+    return {
+      latest: true,
+      state: state,
+      transitionTimestamp: 0,
+      genesis: false,
+    };
+  }
+
+  async resolve(id: bigint, state: bigint): Promise<ResolvedState> {
+    const iden3Id = Id.fromBigInt(id);
+    const stateHex = state.toString(16);
+
+    const did = `did:polygonid:polygon:amoy:${iden3Id.string()}`;
+
+    const didWithState = `${did}?state=${stateHex}`;
+    const response = await fetch(
+      `${this.resolverUrl}/${encodeURIComponent(didWithState)}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+      },
+    );
+    const result = await response.json();
+    const isGenesis = isGenesisStateId(id, state);
+
+    const stateInfo = result.didDocument.verificationMethod[0].info;
+    if (stateInfo == null) throw new Error('state info not found');
+
+    if (stateInfo.id !== did) {
+      throw new Error(`state was recorded for another identity`);
+    }
+
+    if (stateInfo.state !== stateHex) {
+      if (stateInfo.replacedAtTimestamp === '0') {
+        throw new Error(`no information about state transition`);
+      }
+      return {
+        latest: false,
+        genesis: false,
+        state: state,
+        transitionTimestamp: Number.parseInt(stateInfo.replacedAtTimestamp),
+      };
+    }
+
+    return {
+      latest: stateInfo.replacedAtTimestamp === '0',
+      genesis: isGenesis,
+      state,
+      transitionTimestamp: Number.parseInt(stateInfo.replacedAtTimestamp),
+    };
+  }
+}

--- a/src/state/vidosResolver.ts
+++ b/src/state/vidosResolver.ts
@@ -1,19 +1,13 @@
 import { Id } from '@iden3/js-iden3-core';
 import { type IStateResolver, type ResolvedState, isGenesisStateId } from './resolver';
+import type { DIDDocument, DIDResolutionResult, VerificationMethod } from 'did-resolver';
 
-type DidResolutionResult = {
-  didResolutionMetadata: unknown;
-  didDocumentMetadata: unknown;
-  didDocument: {
-    id: string;
-    alsoKnownAs: string[];
-    controller: string;
-    verificationMethod: {
-      id: string;
-      type: string;
-      controller: string;
-      stateContractAddress: string;
-      published: boolean;
+/**
+ * Extended DID resolution result that includes additional information about Polygon ID resolution.
+ */
+type PolygonDidResolutionResult = DIDResolutionResult & {
+  didDocument: DIDDocument & {
+    verificationMethod: (VerificationMethod & {
       info: {
         id: string;
         state: string;
@@ -31,7 +25,7 @@ type DidResolutionResult = {
         createdAtBlock: string;
         replacedAtBlock: string;
       };
-    }[];
+    })[];
   };
 };
 
@@ -57,7 +51,7 @@ export default class VidosResolver implements IStateResolver {
         Authorization: `Bearer ${this.apiKey}`
       }
     });
-    const result = (await response.json()) as DidResolutionResult;
+    const result = (await response.json()) as PolygonDidResolutionResult;
 
     const globalInfo = result.didDocument.verificationMethod[0].global;
     if (globalInfo == null) throw new Error('gist info not found');

--- a/src/state/vidosResolver.ts
+++ b/src/state/vidosResolver.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { Id } from '@iden3/js-iden3-core';
 import { type IStateResolver, type ResolvedState, isGenesisStateId } from './resolver';
 import type { DIDDocument, DIDResolutionResult, VerificationMethod } from 'did-resolver';
@@ -34,7 +35,7 @@ type PolygonDidResolutionResult = DIDResolutionResult & {
  * It can serve as drop-in replacement for EthStateResolver.
  */
 export default class VidosResolver implements IStateResolver {
-  constructor(private readonly resolverUrl: string, private readonly apiKey: string) {}
+  constructor(private readonly resolverUrl: string, private readonly apiKey: string, private readonly network: 'main' | 'mumbai' | 'amoy' = 'main') {}
 
   // Note: implementation closely resembles EthStateResolver because Vidos resolver internally uses the same contract.
   // The only difference is the usage of regular HTTP requests instead of web3 calls.
@@ -43,7 +44,7 @@ export default class VidosResolver implements IStateResolver {
     const stateHex = state.toString(16);
 
     const zeroAddress = '11111111111111111111'; // 1 is 0 in base58
-    const did = `did:polygonid:polygon:amoy:${zeroAddress}?gist=${stateHex}`;
+    const did = `did:polygonid:polygon:${this.network}:${zeroAddress}?gist=${stateHex}`;
 
     const response = await fetch(`${this.resolverUrl}/${encodeURIComponent(did)}`, {
       method: 'GET',
@@ -84,7 +85,7 @@ export default class VidosResolver implements IStateResolver {
     const iden3Id = Id.fromBigInt(id);
     const stateHex = state.toString(16);
 
-    const did = `did:polygonid:polygon:amoy:${iden3Id.string()}`;
+    const did = `did:polygonid:polygon:${this.network}:${iden3Id.string()}`;
 
     const didWithState = `${did}?state=${stateHex}`;
     const response = await fetch(`${this.resolverUrl}/${encodeURIComponent(didWithState)}`, {

--- a/src/state/vidosResolver.ts
+++ b/src/state/vidosResolver.ts
@@ -40,10 +40,7 @@ type DidResolutionResult = {
  * It can serve as drop-in replacement for EthStateResolver.
  */
 export default class VidosResolver implements IStateResolver {
-  constructor(
-    private readonly resolverUrl: string,
-    private readonly apiKey: string,
-  ) {}
+  constructor(private readonly resolverUrl: string, private readonly apiKey: string) {}
 
   async rootResolve(state: bigint): Promise<ResolvedState> {
     const stateHex = state.toString(16);
@@ -51,15 +48,12 @@ export default class VidosResolver implements IStateResolver {
     const zeroAddress = '11111111111111111111'; // 1 is 0 in base58
     const did = `did:polygonid:polygon:amoy:${zeroAddress}?gist=${stateHex}`;
 
-    const response = await fetch(
-      `${this.resolverUrl}/${encodeURIComponent(did)}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${this.apiKey}`,
-        },
-      },
-    );
+    const response = await fetch(`${this.resolverUrl}/${encodeURIComponent(did)}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`
+      }
+    });
     const result = (await response.json()) as DidResolutionResult;
 
     const globalInfo = result.didDocument.verificationMethod[0].global;
@@ -77,7 +71,7 @@ export default class VidosResolver implements IStateResolver {
         latest: false,
         state: state,
         transitionTimestamp: globalInfo.replacedAtTimestamp,
-        genesis: false,
+        genesis: false
       };
     }
 
@@ -85,7 +79,7 @@ export default class VidosResolver implements IStateResolver {
       latest: true,
       state: state,
       transitionTimestamp: 0,
-      genesis: false,
+      genesis: false
     };
   }
 
@@ -96,15 +90,12 @@ export default class VidosResolver implements IStateResolver {
     const did = `did:polygonid:polygon:amoy:${iden3Id.string()}`;
 
     const didWithState = `${did}?state=${stateHex}`;
-    const response = await fetch(
-      `${this.resolverUrl}/${encodeURIComponent(didWithState)}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${this.apiKey}`,
-        },
-      },
-    );
+    const response = await fetch(`${this.resolverUrl}/${encodeURIComponent(didWithState)}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`
+      }
+    });
     const result = await response.json();
     const isGenesis = isGenesisStateId(id, state);
 
@@ -123,7 +114,7 @@ export default class VidosResolver implements IStateResolver {
         latest: false,
         genesis: false,
         state: state,
-        transitionTimestamp: Number.parseInt(stateInfo.replacedAtTimestamp),
+        transitionTimestamp: Number.parseInt(stateInfo.replacedAtTimestamp)
       };
     }
 
@@ -131,7 +122,7 @@ export default class VidosResolver implements IStateResolver {
       latest: stateInfo.replacedAtTimestamp === '0',
       genesis: isGenesis,
       state,
-      transitionTimestamp: Number.parseInt(stateInfo.replacedAtTimestamp),
+      transitionTimestamp: Number.parseInt(stateInfo.replacedAtTimestamp)
     };
   }
 }


### PR DESCRIPTION
This PR is implementing `VidosResolver` to be used as state resolver for the js-iden3. 

Example PR: https://github.com/mailchain/polygonid-tutorial-examples/pull/1 